### PR TITLE
Fixes unresolved promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ const wrapHoneyClient = options => {
 
         if (promise) {
           if (error) {
-            promise.resolve({ dropped: true });
             if (error.message.match(/event dropped due to sampling/)) {
+              promise.resolve({ dropped: true });
             } else {
               promise.reject(error);
             }
@@ -33,7 +33,7 @@ const wrapHoneyClient = options => {
   return {
     sendEventNow: data => {
       return new Promise((resolve, reject) => {
-        const promiseId = data["trace.span_id"] || uuid.v4();
+        const promiseId = uuid.v4();
 
         promises[promiseId] = { resolve, reject };
 


### PR DESCRIPTION
When two events both with the same `trace.span_id` are attempted to send at the same time, then there is a race condition that led to one send promise never resolving. This fixes that issue by not using span ids internally for referencing promises, instead just using a uuid